### PR TITLE
🐋 Use artillery docker image

### DIFF
--- a/performance/Dockerfile
+++ b/performance/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # Artillery.io load tester #
 ############################
-FROM node:14-alpine
+FROM artilleryio/artillery:2.0.21
 ARG http_proxy
 ARG https_proxy
 ARG no_proxy
@@ -13,16 +13,5 @@ WORKDIR /artillery
 
 VOLUME /artillery/reports/
 
-# use proxy & private npm registry
-RUN if [ ! -z "$http_proxy" ] ; then \
-        npm config delete proxy; \
-        npm config set proxy $http_proxy; \
-        npm config set https-proxy $https_proxy; \
-        npm config set no-proxy $no_proxy; \
-   fi ; \
-   [ -z "$npm_registry" ] || npm config set registry=$npm_registry
-
-RUN npm install -g artillery@1.6.0-2
 ENV PERF_MAX_USERS=40
-ENTRYPOINT [ "artillery" ]
 CMD ["run -e development", "-o reports/report.json", "scenario.yml"]


### PR DESCRIPTION
* Utiliser une version artillery plus récente
* Profiter de l'image docker avec playright déjà installé
* J'ai pin la version 2.0.21 parce que la dernière version n'a plus la commande `report` pour générer le fichier html. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the performance testing environment by adopting a modern base configuration, delivering improved reliability and consistent performance.
  - Removed legacy configuration steps such as network proxy setup and manual dependency installation.
  - Simplified the execution process for performance evaluations, resulting in a more predictable, efficient, and stable testing experience for all end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->